### PR TITLE
Fix Links in 'README.md' File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # GitButler Documentation
 
-This is the GitButler documentation, which is hosted by [https://gitbook.com](GitBook) at
-[https://docs.gitbutler.com](docs.gitbutler.com).
+This is the GitButler documentation, which is hosted by [Gitbook](https://gitbook.com) at [docs.gitbutler.com](https://docs.gitbutler.com).
 
 ## Contributing
 


### PR DESCRIPTION
### Commit Body Message

The Links in 'README.md' File were redirecting to a missing file in the Repo, Because the brackets types were switched, see the commit patches for exact details.