### PR TITLE
Fix The Styling of Markdown Files under 'docs' folder and its sub-folders, among other things as well

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,18 +12,11 @@ Here you will find documentation on the product and the way that we're running o
 
 ## Why We're Doing This
 
-{% content-ref url="overview/why-gitbutler.md" %}
-[why-gitbutler.md](overview/why-gitbutler.md)
-{% endcontent-ref %}
+Read about it over [Why GitButler](overview/why-gitbutler.md) Section.
 
 ## What We Do
 
 Currently GitButler does two things. It records everything in a working directory that you have so that you can rewind to any point in time for any file you have. It also does a growing set of Git operations, soon to be a full fledged Git client. You can read more about these features here:
 
-{% content-ref url="features/virtual-branches/" %}
-[virtual-branches](features/virtual-branches/)
-{% endcontent-ref %}
-
-{% content-ref url="features/timeline.md" %}
-[timeline.md](features/timeline.md)
-{% endcontent-ref %}
+- [Virtual Branches](features/virtual-branches/README.md)
+- [Timeline](features/timeline.md)

--- a/docs/community/contact-us.md
+++ b/docs/community/contact-us.md
@@ -2,12 +2,10 @@
 
 There are a few ways to get in touch with us for feedback, bug reports, feature requests, etc.
 
-### Email
+## Email
 
 The simplest way to get in touch with us is to email us at [hello@gitbutler.com](mailto://hello@gitbutler.com)
 
-### Discord
+## Discord
 
-We are also available to chat on our Discord server:
-
-[GitButler Discord](https://discord.gg/MmFkmaJ42D)
+We are also available to chat on our Discord server: Here's [GitButler Discord Server Link](https://discord.gg/MmFkmaJ42D)

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -2,11 +2,9 @@
 
 If you are having technical issues with the GitButler client, here are a few things you can do to help us help you. Or help yourself.
 
-If you get stuck or need help with anything, hit us up over on Discord:
+If you get stuck or need help with anything, hit us up over on Discord, here's [GitButler Discord Server Link](https://discord.gg/MmFkmaJ42D)
 
-[GitButler Discord](https://discord.gg/MmFkmaJ42D)
-
-### Logs
+## Logs
 
 Often the most helpful thing is to look at the logs. GitButler is a Tauri app, so the logs are in your OS's [app log directory](https://docs.rs/tauri/latest/tauri/api/path/fn.app\_log\_dir.html). This should be:
 
@@ -44,7 +42,7 @@ In this directory, there should be rolling daily logs:
 
 ```
 
-### Data Files
+## Data Files
 
 GitButler also keeps it's own data about each of your projects. The virtual branch metadata, your user config stuff, a log of changes in each file, etc. If you want to inspect what GitButler is doing or debug or reset everything, you can go to our data directory.
 

--- a/docs/features/timeline.md
+++ b/docs/features/timeline.md
@@ -15,40 +15,57 @@ layout:
 
 # ⌛ Timeline
 
-{% hint style="danger" %}
-The timeline feature has been temporarily hidden from the UI while we focus our alpha work on the Virtual Branch functionality. It will come back very soon. :pray:
-{% endhint %}
+> [!IMPORTANT]
+> The timeline feature has been temporarily hidden from the UI while we focus our alpha work on the Virtual Branch functionality. It will come back very soon. :pray:
 
 Another feature of GitButler is the project timeline. This tool allows you to find any version of any file that has ever existed in your project from the moment you downloaded GitButler.
 
-### Always Watching
+## Always Watching
 
 When you add a project to GitButler, we will always be in the background, watching the directory like a hawk. Any files that you change that are not in your `.gitignore` file will be automatically saved every time you change them.
 
-{% hint style="info" %}
-The actual implementation of this is that we store CRDT data for all observed file changes inside your `.git` directory under `gb-[long-id-number]`. When we see you've stopped making changes for a few minutes, we flush all of that information to a meta-commit and update a hidden Git reference which you can find by running `git show-ref | grep gitbutler`. If you sign up for GitButler Cloud, we push that data to our servers so your working directory history is backed up.
-{% endhint %}
+> [!NOTE]
+> The actual implementation of this is that we store CRDT data for all observed file changes inside your `.git` directory under `gb-[long-id-number]`. When we see you've stopped making changes for a few minutes, we flush all of that information to a meta-commit and update a hidden Git reference which you can find by running `git show-ref | grep gitbutler`. If you sign up for GitButler Cloud, we push that data to our servers so your working directory history is backed up.
 
 These changes allow us to reconstruct what your working directory looked like at any point in time. You can see visualizations of this data on your project homepage and you can drill into any day or file to play back the changes. You can use this to remind yourself what you did, find previous versions of files that were never committed, revert sections or code you want to go back to, etc.
 
-### The Project Dashboard
+## The Project Dashboard
 
 The Project dashboard shows you a summary of all the changes we have observed for the last few days. This includes any changes to any files and also any git commands (commits, pushes, fetches) that we've seen.
 
-<figure><img src="../../.gitbook/assets/CleanShot 2023-03-14 at 16.11.48@2x.png" alt=""><figcaption><p>My project dashboard</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../.gitbook/assets/CleanShot 2023-03-14 at 16.11.48@2x.png" alt="">
+    <figcaption>
+      <p><i>My project dashboard</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 We also show you what branch you're currently on, if there are uncommitted changes (sort of like `git status`) and allow you to quick commit from here, but we'll cover that more in the [Broken link](broken-reference "mention") docs.
 
-### The Player
+## The Player
 
-<figure><img src="../../.gitbook/assets/CleanShot 2023-03-16 at 17.20.07@2x.png" alt=""><figcaption><p>Working directory history player</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../.gitbook/assets/CleanShot 2023-03-16 at 17.20.07@2x.png" alt="">
+    <figcaption>
+      <p><i>Working directory history player</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Once you have some work saved, you can rewind your working directories time to see every change. Load in day playlists of sessions to find by time, or filter down to the history of a single file. Hit play to watch your changes happen in the order you applied them.
 
-### GitButler Cloud Backup
+## GitButler Cloud Backup
 
 If you sign in to GitButler Cloud then you can go into the settings of your project (the little gear icon on the top right of the project view) and opt into sending your data to your account on our servers. This will back up all your local history several times a day if you're online.
 
-<figure><img src="../../.gitbook/assets/CleanShot 2023-03-14 at 16.16.45@2x.png" alt=""><figcaption></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../.gitbook/assets/CleanShot 2023-03-14 at 16.16.45@2x.png" alt="">
+    <figcaption></figcaption>
+  </figure>
+</div>
 
 This can be toggled off at any time to stop backing up your data.

--- a/docs/features/virtual-branches/README.md
+++ b/docs/features/virtual-branches/README.md
@@ -8,21 +8,32 @@ description: >-
 
 The main feature of GitButler currently is our virtual branch functionality. Here is a quick video showing off some of what you can do when being able to work on multiple branches at the same time.
 
-{% embed url="https://www.youtube.com/watch?v=MRcmnUwrP8A" %}
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=MRcmnUwrP8A">
+    <img src="https://img.youtube.com/vi/MRcmnUwrP8A/0.jpg" alt="Youtube Video Titled 'Intro to Virtual Branches'">
+  </a>
+</div>
 
-Virtual branches are just like normal Git branches, except that you can work on several of them at the same time.&#x20;
+Virtual branches are just like normal Git branches, except that you can work on several of them at the same time.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.25.19@2x.png" alt=""><figcaption><p>An example of working on two branches at the same time, while pending upstream changes wait for you to merge them.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.25.19@2x.png" alt="">
+    <figcaption>
+      <p><i>An example of working on two branches at the same time, while pending upstream changes wait for you to merge them.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
-{% hint style="danger" %}
-**Quick warning.** You cannot use both GitButler virtual branches and normal Git branching commands at the same time, you will have to "commit" to one approach or the other.&#x20;
+> [!WARNING]
+> You cannot use both GitButler virtual branches and normal Git branching commands at the same time, you will have to "commit" to one approach or the other.
 
 The reason is that stock Git can only handle one branch at a time, it does not have tooling to use or understand multiple, so most commands having to do with the index or HEAD or branching (`commit`, `branch`, `checkout`, etc) may behave unexpectedly. Most importantly, do not use normal Git commit tooling or other GUIs.&#x20;
 
-To understand why and how to get out of this, please read our [integration-branch.md](integration-branch.md "mention") docs.
-{% endhint %}
+> [!TIP]
+> To understand why and how to get out of this, please read our [integration-branch.md](integration-branch.md) docs.
 
-### Base Branch
+## Base Branch
 
 With virtual branches, you are not working off of local main or master branches. Everything that you do is on a virtual branch, automatically.&#x20;
 
@@ -32,7 +43,7 @@ Once a base branch is specified, everything in your working directory that diffe
 
 This means that you don't have to create a new branch when you want to start working, you simply start working and then change the branch name later. There is no local "main" or "master" because it doesn't make sense. Everything is a branch, with work that is meant to eventually be integrated into your base branch.
 
-### Virtual Branches
+## Virtual Branches
 
 You can easily work in a single branch at a time, but GitButler can handle several virtual branches at the same time. If you have 3 different changes in one file, you can drag each of the changes to a different virtual branch lane and commit and push them independently.
 
@@ -40,46 +51,67 @@ Each virtual branch is kept in a vertical lane, similar to a kanban board, and e
 
 Each time you commit on a virtual branch, GitButler calculates what that branch would have looked like if the changes you dragged onto it were the only things in your working directory and commits a file tree that looks like that. If you push that commit and inspect it on GitHub (or whatever upstream service you use to collaborate), it should look like that was the only change you made, even though you could potentially still have multiple branches applied in your working directory.
 
-### Applying and Unapplying Branches
+## Applying and Unapplying Branches
 
 Since there isn't just a single branch you can be on, you don't "switch" branches, which implies replacement. You simply "apply" branches, which takes whatever changes they represent and adds them to your working directory. If you don't want those changes in your working directory anymore, you can "unapply" them, which removes only those changes.
 
 Each of these actions is as simple as checking or unchecking a box next to the branch name.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.26.58@2x.png" alt="" width="375"><figcaption><p>Click "unapply" for any branch to stash it and remove it's changes from the working directory</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.26.58@2x.png" alt="" width="375">
+    <figcaption>
+      <p><i>Click "unapply" for any branch to stash it and remove it's changes from the working directory</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 To delete a virtual branch, you simply unapply it, then left click on it and choose "delete".
 
-### Merging Upstream
+## Merging Upstream
 
 Eventually you will have work merged into the branch you chose as your base branch, which will need to be reconciled with all your virtual branches to keep them up to date with where they will eventually need to merge into.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.46.58@2x.png" alt=""><figcaption><p>Click "Merge into common base" to integrate upstream changes into your virtual branches.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.46.58@2x.png" alt="">
+    <figcaption>
+      <p><i>Click "Merge into common base" to integrate upstream changes into your virtual branches.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Upstream work will automatically be shown in your sidebar in the "Trunk" section. When you click "Merge into common base" (or the "Update" button next to your "Applied Branches" section), we will attempt to integrate that work with your existing virtual branches. Each branch, applied or unapplied, will try to be updated with the new work.
 
-{% hint style="info" %}
-We will attempt to rebase any commits in your virtual branches on top of new work (similar to running a `git pull --rebase` on each branch). However, if you already have commits in your branch, we have to create a merge commit to get them up to date.
-{% endhint %}
+> [!NOTE]
+> We will attempt to rebase any commits in your virtual branches on top of new work (similar to running a `git pull --rebase` on each branch).
+> However, if you already have commits in your branch, we have to create a merge commit to get them up to date.
 
 If we cannot update a branch because of merge conflicts, we will unapply the branch automatically and leave it in an unmerged state. You can identify these branches with the blue dot next to them in your branch listing.
 
 If a virtual branch is entirely integrated into upstream, it will be removed and deleted when those changes are integrated. So you can just keep a virtual branch applied locally until it is integrated and it will go away automatically.
 
-### Conflicting Branches
+## Conflicting Branches
 
 You cannot have conflicting branches applied at the same time. Any virtual branch that conflicts with branches that are currently applied will be noted you cannot apply them until you have unapplied the branch or branches they conflict with.
 
-### Merge Conflicts
+## Merge Conflicts
 
 If a virtual branch does have a conflict with your upstream branch and is in a blue dot state, you can fix it by applying it. Applying a conflicting branch will first un-apply all existing virtual branches, then put the merge conflict markers into your working directory and mark conflicted files for you.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 15.38.30@2x.png" alt="" width="375"><figcaption><p>Files in a conflicted state</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 15.38.30@2x.png" alt="" width="375">
+    <figcaption>
+      <p><i>Files in a conflicted state</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 You will need to resolve each file that is marked, then click "Resolve" under each one. Once all files are resolved, you need to commit to create the merge commit that resolves it. Now it is up to date and can be unapplied or applied again easily.
 
 While you are in a conflicted state, you cannot apply or unapply any other branches.
 
-### The End
+## The End
 
 That is our general overview of how Virtual Branches works. We've found that it's way easier and faster than constantly switching back and forth between branches, managing branches all the time, and all the other overhead that comes with branching in Git, while still being able to easily create pull requests and integrate features.

--- a/docs/features/virtual-branches/branch-lanes.md
+++ b/docs/features/virtual-branches/branch-lanes.md
@@ -10,7 +10,12 @@ This could be a local virtual branch that you're working on, or it could be a vi
 
 The interface looks something like this:
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.23.30@2x.png" alt=""><figcaption></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 16.23.30@2x.png" alt="">
+    <figcaption><p><i>An example of working on two branches at the same time, while pending upstream changes wait for you to merge them.</i></p></figcaption>
+  </figure>
+</div>
 
 ## The Sidebar
 
@@ -20,7 +25,12 @@ The sidebar on the left shows you the stashed virtual branches that you have and
 
 The "Trunk" is the view of the base branch that you've set. It will show you essentially a `git log` of `origin/master` or whatever you set as your base branch, and it will show you if there are any commits upstream that you have not integrated locally yet. We will automatically check for new upstream changes every few minutes, but you can also click the update button to check immediately.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.07.10@2x.png" alt=""><figcaption></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.07.10@2x.png" alt="">
+    <figcaption><p><i>A screenshot showcasing the explaination above.</i></p></figcaption>
+  </figure>
+</div>
 
 ### Applied Branches
 
@@ -40,7 +50,14 @@ The next part shows "Stashed branches", which are the virtual branches that you 
 
 When you click on "Applied Branches", you will see your main view, which is a list of the virtual branches that are currently applied into your working directory.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.12.07@2x.png" alt=""><figcaption><p>Here we have two virtual branches. The first one has a PR open, local work that is not pushed and local work that is not committed.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.12.07@2x.png" alt="">
+    <figcaption>
+      <p><i>Here we have two virtual branches. The first one has a PR open, local work that is not pushed and local work that is not committed.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 For each virtual branch lane, there is a list of uncommitted work and committed work. If there is uncommitted work, can type a commit message and commit it locally.
 
@@ -50,7 +67,14 @@ You can drag the uncommitted files from one lane to another in order to separate
 
 You can inspect any file change that is uncommitted by clicking on the file path. GitButler will expand a inspector to the right to show you the diff. If you are logged in, our AI system will try to summarize the work in each hunk as well.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.14.04@2x.png" alt=""><figcaption><p>Inspecting our file change</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.14.04@2x.png" alt="">
+    <figcaption>
+      <p><i>Inspecting our file change</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Once you have committed work, you will see it at the bottom as a list of commits under a tag that indicates that they are local. If you hit the "Push" button, it will attempt to push these commits to the same remote server that your base branch is on.
 
@@ -62,16 +86,37 @@ Any further commits will be marked as local until you push them.
 
 You can always undo your last commit by hitting the "Undo" button on the commit.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.17.17@2x.png" alt="" width="375"><figcaption><p>Hit undo to undo.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.17.17@2x.png" alt="" width="375">
+    <figcaption>
+      <p><i>Hit undo to undo.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 ### Amending Commits
 
 If you made a commit and then make another small change and want it to be in your last commit, you can simply drag the file on top of the last commit to amend it.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.20.14@2x.png" alt="" width="563"><figcaption><p>Drag a file onto the last commit to amend the commit to include that file change.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.20.14@2x.png" alt="" width="563">
+    <figcaption>
+      <p><i>Drag a file onto the last commit to amend the commit to include that file change.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 ### Squashing Commits
 
 If you want to squash two commits together, just start dragging one of the commits and the squash targets will light up.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.18.25@2x.png" alt="" width="563"><figcaption><p>Just drag and drop to squash commits.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.18.25@2x.png" alt="" width="563">
+    <figcaption>
+      <p><i>Just drag and drop to squash commits.</i></p>
+    </figcaption>
+  </figure>
+</div>

--- a/docs/features/virtual-branches/committer-mark.md
+++ b/docs/features/virtual-branches/committer-mark.md
@@ -6,7 +6,7 @@ description: A little way to help us spread the word.
 
 We would like to make sure that GitButler can be free to use for everyone, but there are costs involved in hosting any synchronized client data, AI tooling and so forth. What we thought would be an interesting compromise is to ask our users to offset that by supporting us and our unique approach to that is to ask you to allow us to credit ourselves with commits you have made as your "committer".
 
-### The Committer
+## The Committer
 
 Git actually natively supports having two individuals credited with any commit. The important one is the "author", which is normally the person who writes the code.
 
@@ -14,16 +14,23 @@ The other credit can optionally go to a "committer", which was historically the 
 
 By default, GitButler will credit itself as the "committer" on any virtual branch commits that you make. This helps us spread the word in a fairly non-intrusive way. You don't see the committer when you run `git log` normally, you only really see it on GitHub as a little icon behind the author's icon, like this:
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-07-20 at 10.22.26.gif" alt=""><figcaption><p>What a GitButler aided commit looks like on GitHub</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-07-20 at 10.22.26.gif" alt="">
+    <figcaption>
+      <p><i>What a GitButler aided commit looks like on GitHub</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Now, we realize that not everyone will want this, so there are **two ways** to turn off this functionality.
 
-### GitButler Supporters
+## GitButler Supporters
 
 The first is to become a GitButler Supporter. If you go to: [https://app.gitbutler.com/supporter](https://app.gitbutler.com/supporter), you can pay $5 per month to join our supporters group, which lets you toggle the setting on and off in your client.
 
 Being a supporter also comes with other fun benefits, but this is the only feature based one.
 
-### Engage in the Community
+## Engage in the Community
 
 There is another really easy way to toggle these off, but we ask that you ask us. Join our [Discord server](https://discord.com/invite/MmFkmaJ42D), submit a bug or a feature request and we'll tell you the secret setting. :secret:

--- a/docs/features/virtual-branches/integration-branch.md
+++ b/docs/features/virtual-branches/integration-branch.md
@@ -10,15 +10,22 @@ We're getting the git data to think in three dimensions, then asking 2-D Git how
 
 While some commands cannot work well because of this single-branch limitation (`commit`, `checkout`), we do try our best to keep everything in a state where most other commands work reasonably well. Anything having to do with the index or HEAD is a little problematic, but doable in a smooshed state (all branches look like one), while commands like `log` or `blame` work totally fine with no shenanigans.
 
-### The Integration Commit
+## The Integration Commit
 
 The way that we handle this relatively well is by creating an "integration" commit every time you change the committed state of your collective virtual branches.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 17.17.44@2x.png" alt=""><figcaption><p>An example "integration" commit.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 17.17.44@2x.png" alt="">
+    <figcaption>
+      <p><i>An "integration" commit example.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 So what is an "integration" commit? Well, when you apply or unapply branches, or you commit on one of your applied branches, you change the state of what GitButler sees as your overall committed state with regards to your working directory.&#x20;
 
-### Status, Diff and Log
+## Status, Diff and Log
 
 To keep Git command output for things that look at the index and HEAD (such as `status` or `diff`) somewhat sane, we modify your index to look like the union of all the committed states of all your applied virtual branches. This makes `git diff` and `git status` behave more or less like you would expect.&#x20;
 
@@ -28,19 +35,19 @@ However, to help out, we also write out a branch with a custom commit message th
 
 If you run `git log`, the first commit should be our custom commit message and the tree of that commit is the union of all the committed work on all your applied virtual branches, as though they were all merged together into one (something stock Git can understand).
 
-### Committing, Branching, Checking Out
+## Committing, Branching, Checking Out
 
 However, if you try to use something that writes to HEAD, like `git commit` or `git checkout`, then you might have some headaches. By default, our client will simply overwrite the `gitbutler/integration` branch commit whenever something significant changes.
 
 We won't touch the working directory in an unexpected way, so whatever you commit won't be lost, but the commit itself will be forgotten.  Don't do branch stuff in stock Git while trying to use GitButler for now. We have ideas on how to make this somewhat doable in the future, but right now it's easier on everyone to stick with one or the other.
 
-### Git Add and the Index
+## Git Add and the Index
 
 If you attempt to modify the index directly (running `git add` or `git rm`), GitButler won't notice or care. It will simply overwrite it with whatever it needs during it's operations, so while I wouldn't do it, there is also not a lot of danger.&#x20;
 
 The worst that would happen is that you do some complex `git add -i` patch staging and then we wipe it out by rewriting the index. But again, you shouldn't be using stock Git commands related to committing or branching. You gotta choose one or the other for now, you can't go back and forth super easily.
 
-### Recovering or Stopping GitButler Usage
+## Recovering or Stopping GitButler Usage
 
 If you want to stop using GitButler and go back to using stock Git commands for committing and branching, simply check out another branch. GitButler will realize that you've changed it's branch and stop functioning until you reset it.
 

--- a/docs/features/virtual-branches/merging.md
+++ b/docs/features/virtual-branches/merging.md
@@ -10,7 +10,7 @@ However, it doesn't need to actually make the merge commit and tie those context
 
 The other interesting thing is that you cannot get two branches into a conflicting state while they are both applied, because all code in your working directory has to be owned by something. If you come across a part that overlaps, you have to choose which branch owns it or else unapply one of them.
 
-### Merge Conflicts
+## Merge Conflicts
 
 You also cannot (currently) apply two virtual branches that conflict with each other. That means that the only way to merge two branches that have conflicts is to land one upstream in your base branch first, then integrate that so that it's your base and then pull those conflicting changes into your working directory and solve them.
 
@@ -18,7 +18,14 @@ In other words, branches can only conflict with upstream changes and you can onl
 
 When you do have an upstream conflicting branch, you can choose to apply it, which will unapply all other branches and apply this one with conflict markers into your files. Your only branch lane will look something like this:
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 15.38.24@2x.png" alt="" width="375"><figcaption><p>A virtual branch in a conflicted state.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 15.38.24@2x.png" alt="" width="375">
+    <figcaption>
+      <p><i>A virtual branch in a conflicted state.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 While the branch is in this state, you cannot apply other branches or unapply this one. _(We are working on a way to abort this state, but right now you cannot)._
 
@@ -26,6 +33,13 @@ You need to resolve each issue, then hit the "Resolve" button next to each file 
 
 Once all the files are marked as resolved, you need to commit the resolved merge. This will write a merge commit with both parents so that you have an updated merge base.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 16.56.25@2x.png" alt="" width="375"><figcaption><p>Now you need to commit your resolution.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-07-24 at 16.56.25@2x.png" alt="" width="375">
+    <figcaption>
+      <p><i>Now you need to commit your resolution.</i></p>
+    </figcaption
+  ></figure>
+</div>
 
 Once the resolution is committed, you can unapply and apply branches again.

--- a/docs/features/virtual-branches/pushing-and-fetching.md
+++ b/docs/features/virtual-branches/pushing-and-fetching.md
@@ -8,13 +8,13 @@ Currently GitButler will only do network communication over the SSH protocol, so
 
 There are three different keys that GitButler will look for and attempt to use. It cannot currently supply a password, so one of the three needs to be passwordless.
 
-### The SSH Keys
+## The SSH Keys
 
 The first we will look for and try to use is `~./ssh/id_rsa`, which you may already have set up. It's a fairly common key for existing Git users to have, so in many cases, things will just work.
 
 We'll also look for `~/.ssh/id_ecdsa` and try that.
 
-### GitButler's Key
+## GitButler's Key
 
 In case that doesn't work (they doesn't exist, has a password, it's a format that [isn't accepted upstream](https://github.blog/2021-09-01-improving-git-protocol-security-github/), etc), we will look for `~/.ssh/id_ed25519`.&#x20;
 
@@ -24,6 +24,13 @@ If you go to your Account area (click on the link in the top right corner of you
 
 In GitHub, you can do that [here](https://github.com/settings/ssh/new). In GitLab, it's [here](https://gitlab.com/-/profile/keys). If you're running something else, it should be a similar process, but it has to be SSH and able to handle Ed25519 keys.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-08-09 at 13.08.18@2x.png" alt=""><figcaption></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-08-09 at 13.08.18@2x.png" alt="">
+    <figcaption>
+      <p><i>A screenshot showcasing an ed25519 SSH Key.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Once that's done, GitButler will be able to automatically fetch upstream work and push new branches to your upstream server.

--- a/docs/features/virtual-branches/remote-branches.md
+++ b/docs/features/virtual-branches/remote-branches.md
@@ -10,13 +10,27 @@ For instance, when a coworker pushes a new branch to the server and opens a pull
 
 We will show these new remote branches in this sidebar.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.24.49@2x.png" alt=""><figcaption><p>Remote branches will show up here automatically.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.24.49@2x.png" alt="">
+    <figcaption>
+      <p><i>Remote branches will show up here automatically.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
-### Applying Remote Branches
+## Applying Remote Branches
 
 Remote branches cannot be applied like virtual branches, we need to convert them to the more rich virtual branch data structure first. To do this, just click on a branch to see the "Apply" button.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.26.46@2x.png" alt=""><figcaption><p>Click Apply to add this remote branch to your list of applied branches and pull it's changes into your working directory.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-11-30 at 17.26.46@2x.png" alt="">
+    <figcaption>
+      <p><i>Click Apply to add this remote branch to your list of applied branches and pull it's changes into your working directory.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Clicking the "apply" button will turn that remote branch into a tracked virtual branch (sort of like `git checkout -b branch-name origin/branch-name`) and will immediately try to apply it to your working directory as an applied virtual branch. If it can't do so cleanly, it will simply store it as an unapplied virtual branch that you can try to apply later.
 

--- a/docs/features/virtual-branches/verifying-commits.md
+++ b/docs/features/virtual-branches/verifying-commits.md
@@ -12,9 +12,23 @@ To make this work, a signature is added to the commit header and then that signa
 
 This is what a verified commit looks like on both systems:
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 16.40.14@2x.png" alt=""><figcaption><p>A verified commit on GitLab</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 16.40.14@2x.png" alt="">
+    <figcaption>
+      <p><i>A verified commit on GitLab.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 16.42.31@2x.png" alt=""><figcaption><p>Verified and non-verified commits on GitHub</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 16.42.31@2x.png" alt="">
+    <figcaption>
+      <p><i>Verified and non-verified commits on GitHub.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 This means that the server has a public key that you used to sign the commits that is associated to your account and has verified that this user actually signed this commit.
 
@@ -23,34 +37,60 @@ In order for this to work, you need to:
 1. Tell GitButler to sign your commits
 2. Upload your key as a "signing key" to GitHub or GitLab (or elsewhere)
 
-### Telling GitButler to Sign
+## Telling GitButler to Sign
 
 Telling GitButler to sign commits is very easy. For simplicity, currently we will only sign with the ed25519 SSH key that we generate, so it's really just flipping a switch in your settings.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.40.52@2x.png" alt=""><figcaption><p>Telling GitButler to sign your commits</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.40.52@2x.png" alt="">
+    <figcaption>
+      <p><i>Telling GitButler to sign your commits.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 This actually just sets a global Git setting named `gitbutler.signCommits`, so technically you could do this via `git config` instead if you prefer.
 
-### Upload Your Signing Key
+## Upload Your Signing Key
 
 For GitHub or GitLab to verify your signatures, you need to say that the SSH key we generated and are using is a valid signing key for your user. You can copy the public key in the settings page by clicking the "Copy to Clipboard" button.
 
-#### Adding to GitHub
+### Adding to GitHub
 
 You can click on the "Add key to GitHub" link in the settings page right about the signing toggle, or you can go [here](https://github.com/settings/ssh/new) ([https://github.com/settings/ssh/new](https://github.com/settings/ssh/new)) to paste that public key in.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.48.05@2x.png" alt=""><figcaption><p>Be sure to change the type to "Signing Key"</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.48.05@2x.png" alt="">
+    <figcaption>
+      <p><i>Be sure to change the type to "Signing Key"</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Now your signed commits should show up as "Verified".
 
-#### Adding to GitLab
+### Adding to GitLab
 
 For GitLab you need to go to "SSH Keys" in your profile: [https://gitlab.com/-/profile/keys](https://gitlab.com/-/profile/keys) and click the "Add new key" button.
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.50.22@2x.png" alt="" width="563"><figcaption><p>Add new key here.</p></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.50.22@2x.png" alt="" width="563">
+    <figcaption>
+      <p><i>Add new key here.</i></p>
+    </figcaption>
+  </figure>
+</div>
 
 Now paste in the public SSH key you copied from GitButler, name it and make sure the "Usage Type" is either "Signing" or "Authentication and Signing".
 
-<figure><img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.51.22@2x.png" alt="" width="563"><figcaption></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../../../.gitbook/assets/CleanShot 2023-09-23 at 21.51.22@2x.png" alt="" width="563">
+    <figcaption></figcaption>
+  </figure>
+</div>
 
 Now all your GitButler generated commits will be verified on that platform!

--- a/docs/troubleshooting/fetch-push.md
+++ b/docs/troubleshooting/fetch-push.md
@@ -2,48 +2,48 @@
 
 If you are having trouble pushing or fetching from a remote, this is likely related to git authentication. Here are a few configuration options you can try out, found in the project settings.
 
-### Available authentication methods
+## Available authentication methods
 
 GitButler can be configured to use several different git authentication methods. You can switch between them in your project settings. You can try multiple diffirent options and see if any of them are appropriate for your setup.
 
-#### Auto detect
+### Auto detect
 
 This is the default setting. GitButler will attempt multiple authentication methods (which may make this option slower in some cases). If you have a GitHub integration set up, the app will also attempt to use that.
 
-#### Use an existing SSH key
+### Use an existing SSH key
 
 If already have an SSH key set up (eg. `~/.ssh/id_rsa`), you can instruct GitButler to use it. In case the key is password protected, you can also provide the password to it (which will be stored locally).
 
-#### Use locally generated SSH key
+### Use locally generated SSH key
 
 This option generates a new SSH key which will be stored locally in the application [data dir](../development/debugging.md#data-files). For this to work you will need to add the new public key to your Git remote provider.
 
-#### Use a git credential helper
+### Use a git credential helper
 
 If your system is set up with a credential helper, GitButler can use that. For more info on git credential helpers, see this [article](https://git-scm.com/doc/credential-helpers)
 
-### Not yet implemented authentication methods
+## Not yet implemented authentication methods
 
-#### FIDO security keys (YubiKey, etc.)
+### FIDO security keys (YubiKey, etc.)
 
 Tracked in GitHub issue [#2661](https://github.com/gitbutlerapp/gitbutler/issues/2661)
 
-#### Keys managed by 1Password
+### Keys managed by 1Password
 
 Tracked in GitHub issue [#2779](https://github.com/gitbutlerapp/gitbutler/issues/2779)
 
-#### Host certificate checks
+### Host certificate checks
 
 There is an option to ignore host certificate checks when authenticating with ssh. This may be a helpful option to enable in some cases.
 
-### Other known issues
+## Other known issues
 
-#### Git remote servers with a non-standard SSH port
+### Git remote servers with a non-standard SSH port
 
 In some cases, the git remote may be setup on a port number other than 22. If the port is set in your `~/.ssh/config` file, GitButler will not be able to recognize that - tracked in GitHub issue [#2700](https://github.com/gitbutlerapp/gitbutler/issues/2700).
 
 As a workaround you may set your remote in the [SSH format](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols) (eg. `ssh://git@example.com:3022/foo/bar.git`)
 
-### Help on Discord
+## Help on Discord
 
 If none of the available options helps, feel free to hop on our [Discord](https://discord.gg/MmFkmaJ42D) and we will be happy to help you out.

--- a/docs/troubleshooting/recovering-stuff.md
+++ b/docs/troubleshooting/recovering-stuff.md
@@ -6,7 +6,7 @@ description: How to dig around our internal data to find (nearly) anything
 
 GitButler saves data in a few different ways. As we're still in beta, sometimes things might break and it may look like you've lost work, but you almost certainly haven't. We're pretty good about saving stuff a lot. Here's how to recover almost anything you had in your working directory or virtual branches.
 
-### GitButler References
+## GitButler References
 
 If everything crashes or the UI isn't working at all, you may be surprised to know that even though your virtual branches don't show up in a normal `git branch` output, we _do_ actually constantly write them out as Git references (just not in `refs/heads`).
 
@@ -26,9 +26,14 @@ If you've committed everything on a virtual branch, the reference will just poin
 
 So for example, if I have the following two virtual branches, one fully committed and one with work pending:
 
-<figure><img src="../.gitbook/assets/CleanShot 2024-02-23 at 10.30.27@2x.png" alt=""><figcaption></figcaption></figure>
+<div align="center">
+  <figure>
+    <img src="../.gitbook/assets/CleanShot 2024-02-23 at 10.30.27@2x.png" alt="">
+    <figcaption></figcaption>
+  </figure>
+</div>
 
-&#x20;I can view the git branches like this:
+I can view the git branches like this:
 
 ```
 ❯ git show gitbutler/Convert-tables-to-utf8mb4
@@ -112,7 +117,7 @@ To github.com:gitbutlerapp/web.git
 
 ```
 
-### GitButler Sessions
+## GitButler Sessions
 
 Ok, let's say that your work was not in one of those refs for some reason. Maybe you hit some weird bug and it completely changed everything in a way where now you're sitting on the couch in the dark with a glass of whisky, slowly mumbling the word "GitButler..." and plotting your revenge.
 
@@ -198,7 +203,7 @@ Date:   Fri Feb 9 15:24:28 2024 +0100
 
 While `branches` has interesting data (all our virtual branch coolness), we probably don't need to look at that for data recovery purposes.
 
-### Recovering a Working Directory State
+## Recovering a Working Directory State
 
 The nice thing about this is that we then have an automatic backup of our working directory at very regular intervals whenever we're touching any files in our project directory. You can use Git plumbing commands to do whatever you want with the `wd` subtree in any of those "check" commits.
 
@@ -284,7 +289,7 @@ Date:   Fri Feb 9 13:06:29 2024 +0100
 
 Now the working directory snapshot from a month ago looks like a new commit on top of `origin/master`. It's a real branch, we can check it out, push it, etc.
 
-### CRDTs
+## CRDTs
 
 Now, if you need a version of a file _between_ two session snapshots, you can also technically recover that, because we _also_ keep a CRDT of each file we see changed. These are found in the `session/deltas` tree in each session.&#x20;
 


### PR DESCRIPTION
### Changes made to to the Markdown files are the following:
  1. Add a \<div\> attribute to every screenshot, with its \<figure\> and \<figcaption\> attributes inside said \<div\> So I can align all elements inside the \<div\> to be center aligned.
  2. Made all paragraph elements inside \<figcaption\> attribute to be Italic using the \<i\> attribute.
  3. Added some paragraphs to some of the empty \<figcaption\> attributes.
  4. Made the Heading Levels generally bigger to make the reading experience better and clear-er. or in other words, heading level 3 became level 2, heading level 4 became 3, and so on...
  5. Fixed the Hint Icons in every Markdown file that uses them, And used Github's Supported way of doing it, for example:
     ```
     > [!NOTE]
     > This is a side note.

     > [!WARNING]
     > Warning User!
     ```
     The full list I've used is found in this discussion post on Github: https://github.com/orgs/community/discussions/16925
  6. All of the Markdown Files has the above edits applied, Except The 'releases.md' file under the 'releases' folder.